### PR TITLE
feat: prevent tab/space bar's default behaviors

### DIFF
--- a/front/src/components/WordsContainer.tsx
+++ b/front/src/components/WordsContainer.tsx
@@ -1,4 +1,5 @@
 import UserType from "../pages/TypingTestInterface/TypeTestComponents/UserType";
+import { useEffect, useRef } from "react";
 
 interface WordsProps{
     userInput: string;
@@ -7,36 +8,72 @@ interface WordsProps{
 }
 
 export default function WordsContainer(props: WordsProps) {
+
+    const typingBoxRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        const typingBox = typingBoxRef.current;
+
+        // prevents tabbing out of the typing box
+        if (typingBox) {
+            // selects elements that are focusable
+            const allFocusableElems = document.querySelectorAll(
+                'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+            );
+            
+            // sets their tabindex to -1 so they are not focusable
+            allFocusableElems.forEach((elem) => {
+                elem.setAttribute('tabIndex', '-1');
+            });
+
+            // sets focus on the typing box
+            typingBox.setAttribute('tabIndex', '0');
+            typingBox.focus();
+            
+            // resets the tab indices when the component unmounts
+            return () => {
+                allFocusableElems.forEach((elem) => {
+                    elem.setAttribute('tabIndex', '0');
+                });
+            };  
+        }
+    }, []);
+
+    // prevents spacebar from scrolling on typing box
+    useEffect(() => {
+        const typingBox = typingBoxRef.current;
+        
+        function handleKeyDown(e: KeyboardEvent) {
+          if (e.key === ' ' || e.key === 'Spacebar') {
+            e.preventDefault();
+          }
+        }
+
+        if (typingBox) {
+            typingBox.addEventListener('keydown', handleKeyDown);
+        }
+    }, []);
+
     return (
         <div
+        ref={typingBoxRef}
         className="typetest"
-        autoFocus={true}
-        onBlur={({ target }) => target.focus()}
         >
-        <div
-            className="usertyped"
-            onKeyDown={(e) => {
-            if (e.code === "Tab") {
-                e.preventDefault();
-                console.log("tabbed");
-            }
-            }}
-        >
-            <pre>
-            <code>
-                <UserType
-                userInput={props.userInput}
-                words={props.words}
-                typeMode={props.typeMode}
-                />
-            </code>
-            </pre>
-        </div>
-        <div className="codesnippet">
-            <pre>
-            <code>{props.words}</code>
-            </pre>
-        </div>
+            <div className="usertyped">
+                <pre>
+                <code>
+                    <UserType
+                    userInput={props.userInput}
+                    words={props.words}
+                    typeMode={props.typeMode}
+                    />
+                </code>
+                </pre>
+            </div>
+            <div className="codesnippet">
+                <pre>
+                <code>{props.words}</code>
+                </pre>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
Added useEffects to prevent the use of Tab/Space to move focus to other elements/scroll on the typing box div.